### PR TITLE
Mute screen function should not filter on templates

### DIFF
--- a/includes/screens.php
+++ b/includes/screens.php
@@ -23,7 +23,9 @@ function bp_mute_all_screen() {
 	 * @since 1.0.0
 	 */
 	do_action( 'bp_mute_all_screen' );
-
+	
+	bp_mute_load_template_content();
+	
 	bp_core_load_template( 'members/single/plugins' );
 }
 
@@ -40,42 +42,23 @@ function bp_mute_friends_screen() {
 	 * @since 1.0.0
 	 */
 	do_action( 'bp_mute_friends_screen' );
-
+	
+	bp_mute_load_template_content();
+	
 	bp_core_load_template( 'members/single/plugins' );
 }
 
 /**
- * Filter the template location.
- *
- * @since 1.0.0
- *
- * @param string $found_template Located template path.
- * @param array $templates Array of templates to attempt to load.
- * @param string
+ * Load actual content to the plugins template
+ * 
  */
-function bp_mute_load_template_filter( $found_template, $templates ) {
-
-	global $bp;
-
-	if ( ! bp_is_current_component( $bp->mute->slug ) ) {
-
-		return $found_template;
-	}
-
-	if ( empty( $found_template ) ) {
-
-		bp_register_template_stack( 'bp_mute_get_template_directory', 14 );
-
-		$found_template = locate_template( 'members/single/plugins.php', false, false );
+function bp_mute_load_template_content() {
 
 		add_action( 'bp_after_member_plugin_template', 'bp_mute_disable_members_loop_ajax' );
 
 		add_action( 'bp_template_content', 'bp_mute_template_part' );
-	}
 
-	return $found_template;
 }
-add_filter( 'bp_located_template', 'bp_mute_load_template_filter', 10, 2 );
 
 /**
  * Get a template directory location.


### PR DESCRIPTION
Hi Henry,
Mute screen is generated using "plugins.php" so there is no need to filter on templates. The current setup does not work for themes which do not use theme compat.

Instead, It should simply load "plugins.php" and add the generated content.

Thank you
Brajesh